### PR TITLE
Add Index in Events

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,7 +182,7 @@ loop:
 					panic(err)
 				}
 				raw := data[4]
-				index := uint32(binary.BigEndian.Uint16(data[8:10]))
+				index := binary.BigEndian.Uint32(data[6:10])
 
 				s.EventFacility = SubscriptionEventFacility(raw & 0x0F).String()
 				s.EventType = SubscriptionEventType(raw & 0x30).String()

--- a/client.go
+++ b/client.go
@@ -175,14 +175,18 @@ loop:
 			}
 			if rsp == commandSubscribeEvent && tag == 0xffffffff {
 				var s SubscriptionEvent
-				var raw uint32
-				err := bread(buff, uint32Tag, &raw)
+				data := make([]byte, 10)
+				_, err := buff.Read(data)
 				if err != nil {
 					log.Println(err)
 					panic(err)
 				}
+				raw := data[4]
+				index := uint32(binary.BigEndian.Uint16(data[8:10]))
+
 				s.EventFacility = SubscriptionEventFacility(raw & 0x0F).String()
 				s.EventType = SubscriptionEventType(raw & 0x30).String()
+				s.Index = &index
 				select {
 				case c.Events <- s:
 				default:


### PR DESCRIPTION
Hello,

When you subscribe to receive events, the index field is missing.
This PR adds the index field, so you can target the sink that has changed.